### PR TITLE
Update CFLAGS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get install -qq -y build-essential flex-old
 
       - name: Make
-        run: bash -c "cd src/ && CFLAGS='-std=gnu89' make && make install"
+        run: bash -c "cd src/ && CFLAGS='-std=gnu89 -fcommon' make && make install"
 
       - name: Run tests
         run: ruby test/test.rb

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Requirements:
 ```bash
 cd src/
 make clean
-CFLAGS='-std=gnu89 -Wno-return-type' make LOADLIBES='-ll'
+CFLAGS='-std=gnu89 -Wno-return-type -Wno-implicit-function-declaration' make LOADLIBES='-ll'
 make install
 ```
 
-(Tested on macOS High Sierra Version 10.13.5, Apple LLVM version 9.1.0.)
+(Tested on Apple M1, macOS Ventura 13.1, Apple clang version 14.0.0.)
 
 ### Linux
 
@@ -61,7 +61,7 @@ CFLAGS='-std=gnu89' make
 make install
 ```
 
-(Tested on Ubuntu 16.04 and 18.04.)
+(Tested on Ubuntu 22.04.)
 
 ## Usage
 


### PR DESCRIPTION
Update CFLAGS for Linux and macOS.

See https://github.com/perseids-tools/morpheus/pull/6 for more information.